### PR TITLE
Baud rate fix, MQTT elimination using HA API (in case this repo is still active)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode/
+/.idea/

--- a/README.md
+++ b/README.md
@@ -12,10 +12,7 @@ This HA addon will automatically add the build tools, download the latest source
 
 ## System Dependencies
 
-The following should be added to you HA build via the addon store.
-
-- Mosquitto broker
-- Node-RED
+**None**
 
 ## Addon Configuration
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,20 +10,16 @@ arch:
   - i386
 options:
   port: "/dev/ttyUSB0"
-  mqtt_server: "localhost"
-  mqtt_port: 1883
-  mqtt_user: "user"
-  mqtt_password: "password"
+  baudrate: 115200
   repeat: "60"
 schema:
   port: str
-  mqtt_server: str
-  mqtt_port: int
-  mqtt_user: str
-  mqtt_password: str
+  baudrate: int
   repeat: int
 init: false
 startup: once
 uart: true
 host_network: true
 video: false
+homeassistant_api: true
+hassio_api: false

--- a/doc/GQ-RFC1201.txt
+++ b/doc/GQ-RFC1201.txt
@@ -3,7 +3,7 @@ GQ-RFC1201
 
 GQ Geiger Counter Communication Protocol
 ***************************************************
-Ver 1.10
+Ver 1.40    Jan-2015
 
 
 Status of this Memo
@@ -26,13 +26,19 @@ Abstract
 Serial Port configuration
 **************************
 
-The serial port communication is based on a fixed baud rate.
+For the GMC-300 V3.xx and earlier version, the serial port communication is based on a fixed baud rate.
 
 Baud: 57600
 Data bit: 8
 Parity: None
 Stop bit: 1
 Control: None
+
+For the GMC-300 Plus V4.xx and later version firmware,  115200 BPS is used.
+
+For GMC-320, the serial port communication baud rate is variable. It should be one of the followings:
+
+1200,2400,4800,9600,14400,19200,28800,38400,57600,115200 BPS.  The factory default is 115200 BPS.
 
 
 **************************
@@ -202,3 +208,144 @@ Return: 0xAA
 
 Firmware supported: GMC-280, GMC-300 Re.2.20 or later
 
+
+14. Set realtime clock year
+
+command: <SETDATEYY[D0]>>
+
+	D0 is the year value in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+
+15. Set realtime clock month
+
+command: <SETDATEMM[D0]>>
+
+	D0 is the month value in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+
+16. Set realtime clock day
+
+command: <SETDATEDD[D0]>>
+
+	D0 is the day of the month value in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+17. Set realtime clock hour
+
+command: <SETTIMEHH[D0]>>
+
+	D0 is the hourvalue in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+18. Set realtime clock minute
+
+command: <SETTIMEMM[D0]>>
+
+	D0 is the minute value in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+
+
+19. Set realtime clock second
+
+command: <SETTIMESS[D0]>>
+
+	D0 is the second value in hexdecimal
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.2.23 or later
+
+
+20. Reset unit to factory default
+
+command: <FACTORYRESET>>
+
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.3.00 or later
+
+
+21. Reboot unit
+
+command: <REBOOT>>
+
+	
+Return: None
+
+Firmware supported: GMC-280, GMC-300 Re.3.00 or later
+
+
+22. Set year date and time
+
+command: <SETDATETIME[YYMMDDHHMMSS]>>
+
+	
+Return: 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.3.00 or later
+
+
+
+23. Get year date and time
+
+command: <GETDATETIME>>
+
+	
+Return: Seven bytes data: YY MM DD HH MM SS 0xAA
+
+Firmware supported: GMC-280, GMC-300 Re.3.00 or later
+
+
+
+24. Get temperature
+
+command: <GETTEMP>>
+
+Return: Four bytes celsius degree data in hexdecimal: BYTE1,BYTE2,BYTE3,BYTE4
+	Here: BYTE1 is the integer part of the temperature.
+	      BYTE2 is the decimal part of the temperature.
+	      BYTE3 is the negative signe if it is not 0.  If this byte is 0, the then current temperture is greater than 0, otherwise the temperature is below 0.
+`	      BYTE4 always 0xAA
+
+Firmware supported: GMC-320 Re.3.01 or later
+
+
+25. Get gyroscope data
+
+command: <GETGYRO>>
+
+Return: Seven bytes gyroscope data in hexdecimal: BYTE1,BYTE2,BYTE3,BYTE4,BYTE5,BYTE6,BYTE7
+	Here: BYTE1,BYTE2 are the X position data in 16 bits value. The first byte is MSB byte data and second byte is LSB byte data.
+	      BYTE3,BYTE4 are the Y position data in 16 bits value. The first byte is MSB byte data and second byte is LSB byte data.
+	      BYTE5,BYTE6 are the Z position data in 16 bits value. The first byte is MSB byte data and second byte is LSB byte data.
+	      BYTE7 always 0xAA
+
+Firmware supported: GMC-320 Re.3.01 or later
+
+
+26. Power ON
+
+Command: <POWERON>>
+
+Return: none
+
+Firmware supported: GMC-280, GMC-300, GMC-320 Re.3.10 or later

--- a/rootfs/etc/services.d/gmc320/run
+++ b/rootfs/etc/services.d/gmc320/run
@@ -19,7 +19,7 @@ bashio::log.info "Device serial number: ${SERIAL}"
 
 # Send homeassistant MQTT discovery message
 #bashio::log.info "Sending MQTT discovery message"
-#mosquitto_pub -r -u ${MQTT_USER} -P ${MQTT_PASSWORD} -p ${MQTT_PORT} -h ${MQTT_SERVER} -t "homeassistant/sensor/gmc3xx_${SERIAL}/config" -m '{ "state_topic": "homeassistant/sensor/gmc3xx_${SERIAL}/state","cpm": {"name": "Radation", "device_class": None, "unit_of_measurement": "cpm", "icon": "mdi:radioactive", "state_class": "measurement"},"battery": {"name": "Battery", "device_class": "battery", "unit_of_measurement": "%", "icon": None, "state_class": "measurement"}, "temperature": {"name": "Temperature", "device_class": "temperature", "unit_of_measurement": "°C", "icon": None, "state_class": "measurement"} }'
+#mosquitto_pub -r -u ${MQTT_USER} -P ${MQTT_PASSWORD} -p ${MQTT_PORT} -h ${MQTT_SERVER} -t "homeassistant/sensor/gmc3xx_${SERIAL}/config" -m '{ "state_topic": "homeassistant/sensor/gmc3xx_${SERIAL}/state","cpm": {"name": "Radiation", "device_class": None, "unit_of_measurement": "cpm", "icon": "mdi:radioactive", "state_class": "measurement"},"battery": {"name": "Battery", "device_class": "battery", "unit_of_measurement": "%", "icon": None, "state_class": "measurement"}, "temperature": {"name": "Temperature", "device_class": "temperature", "unit_of_measurement": "°C", "icon": None, "state_class": "measurement"} }'
 
 # 'x': {'name': 'x', 'device_class': 'None', 'unit_of_measurement': 'deg', 'icon': 'None', 'state_class': 'measurement'}, \
 # 'y': {'name': 'y', 'device_class': 'None', 'unit_of_measurement': 'deg', 'icon': 'None', 'state_class': 'measurement'}, \

--- a/rootfs/etc/services.d/gmc320/run
+++ b/rootfs/etc/services.d/gmc320/run
@@ -2,34 +2,36 @@
 # ==============================================================================
 # Start gmc320 service
 # ==============================================================================
-CONFIG_PATH=/data/options.json
 
 PORT="$(bashio::config 'port')"
-MQTT_SERVER="$(bashio::config 'mqtt_server')"
-MQTT_PORT="$(bashio::config 'mqtt_port')"
-MQTT_USER="$(bashio::config 'mqtt_user')"
-MQTT_PASSWORD="$(bashio::config 'mqtt_password')"
+BAUDRATE="$(bashio::config 'baudrate')"
 DELAY="$(bashio::config 'repeat')"
 
-bashio::log.info "Starting gmc3xx"
+set +e
+
+bashio::log.info "Starting gmc3xx, using port ${PORT} and baudrate ${BAUDRATE}"
 
 # Get the device serial number
-SERIAL=$(gmc320 ${PORT} | jq -r .serial)
+RESPONSE=$(gmc320 ${PORT} ${BAUDRATE})
+bashio::log.info "response: ${RESPONSE}"
+SERIAL=$(echo "${RESPONSE}" | jq -r .attributes.serial)
 bashio::log.info "Device serial number: ${SERIAL}"
 
-# Send homeassistant MQTT discovery message
-#bashio::log.info "Sending MQTT discovery message"
-#mosquitto_pub -r -u ${MQTT_USER} -P ${MQTT_PASSWORD} -p ${MQTT_PORT} -h ${MQTT_SERVER} -t "homeassistant/sensor/gmc3xx_${SERIAL}/config" -m '{ "state_topic": "homeassistant/sensor/gmc3xx_${SERIAL}/state","cpm": {"name": "Radiation", "device_class": None, "unit_of_measurement": "cpm", "icon": "mdi:radioactive", "state_class": "measurement"},"battery": {"name": "Battery", "device_class": "battery", "unit_of_measurement": "%", "icon": None, "state_class": "measurement"}, "temperature": {"name": "Temperature", "device_class": "temperature", "unit_of_measurement": "°C", "icon": None, "state_class": "measurement"} }'
 
-# 'x': {'name': 'x', 'device_class': 'None', 'unit_of_measurement': 'deg', 'icon': 'None', 'state_class': 'measurement'}, \
-# 'y': {'name': 'y', 'device_class': 'None', 'unit_of_measurement': 'deg', 'icon': 'None', 'state_class': 'measurement'}, \
-# 'z': {'name': 'z', 'device_class': 'None', 'unit_of_measurement': 'deg', 'icon': 'None', 'state_class': 'measurement'}, \
-
-
-# Send the readings
+# Send the readings to http://supervisor/core/api
 bashio::log.info "Start sending data"
 while true; do
-	DATA=$(gmc320 ${PORT})
-	mosquitto_pub -u ${MQTT_USER} -P ${MQTT_PASSWORD} -p ${MQTT_PORT} -h ${MQTT_SERVER} -t "homeassistant/sensor/gmc3xx_${SERIAL}" -m "${DATA}"
+  bashio::log.info "Requesting data, using port ${PORT} and baudrate ${BAUDRATE}"
+	DATA=$(gmc320 ${PORT} ${BAUDRATE})
+	bashio::log.info "response: ${DATA}"
+	#mosquitto_pub -u ${MQTT_USER} -P ${MQTT_PASSWORD} -p ${MQTT_PORT} -h ${MQTT_SERVER} -t "homeassistant/sensor/gmc3xx_${SERIAL}" -m "${DATA}"
+	HTTP_CODE=$(curl -s -X POST -o response.txt -w "%{http_code}" \
+    -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "${DATA}" \
+    "http://supervisor/core/api/states/sensor.gmc3xx_${SERIAL}")
+  HTTP_RESPONSE=$(cat response.txt)
+  bashio::log.info "HA API HTTP code: ${HTTP_CODE}"
+  bashio::log.info "HA API HTTP Response: ${HTTP_RESPONSE}"
 	sleep ${DELAY}
 done

--- a/rootfs/gmc320.c
+++ b/rootfs/gmc320.c
@@ -205,8 +205,8 @@ int setDateTime(int device) {
 
 int main(int argc, char *argv[]) {
 
-	if (argc != 2) {
-		printf("You need to specify the serial device used by the GMC radiation monitor i.e. %s /dev/ttyUSB0\n", argv[0]);
+	if (argc < 2) {
+		printf("You need to specify at least the serial device used by the GMC radiation monitor i.e. %s /dev/ttyUSB0\n", argv[0]);
 		return 1;
 	}
 	int baudrate = 115200;
@@ -216,10 +216,11 @@ int main(int argc, char *argv[]) {
 		if(strlen(argv[2]) > 0){
 			long argv2 = strtol(argv[2], &p, 10);
 			if (*p != '\0' || errno != 0) {
-			    	printf("failed to parse baud rate, fallback to default");
+                //printf("failed to parse baud rate, fallback to default");
 				baudrate = 115200;
+			} else {
+			    baudrate = (int)argv2;
 			}
-			baudrate = (int)argv2;
 		}
 	}
 
@@ -230,31 +231,36 @@ int main(int argc, char *argv[]) {
 		printf("Cannot open specified serial device\n");
 		return 1;
 	};
+
+	int cpm = gmc_get_cpm(serial_port);
 	printf("{");
-		char version[20];
-		gmc_get_version(serial_port, version);
-		printf(" \"version\" : \"%s\",", version);
+	    printf(" \"state\" : %i,",cpm);
 
-		char serialNumber[20];
-		gmc_get_serial(serial_port, serialNumber);
-		printf(" \"serial\" : \"%s\",",serialNumber);
+        printf("\"attributes\": {");
+            printf(" \"unit_of_measurement\" : \"cpm\",");
 
-		int cpm = gmc_get_cpm(serial_port);
-		printf(" \"cpm\" : %i,",cpm);
+            char version[20];
+            gmc_get_version(serial_port, version);
+            printf(" \"version\" : \"%s\",", version);
 
-		float temp =gmc_get_temperature(serial_port);
-		printf(" \"temp\" : %.1f,", temp);
+            char serialNumber[20];
+            gmc_get_serial(serial_port, serialNumber);
+            printf(" \"serial\" : \"%s\",",serialNumber);
 
-		float volt = gmc_get_volt(serial_port)/10;
-		printf(" \"volt\" : %0.1f,", volt);
+            float temp =gmc_get_temperature(serial_port);
+            printf(" \"temp\" : %.1f,", temp);
 
-		Gyro_Sensor gyro;
-		gmc_get_gyro(serial_port, &gyro);
-		printf(" \"x\" : %d,\"y\" : %d, \"z\" : %d", gyro.x, gyro.y, gyro.z);
+            float volt = gmc_get_volt(serial_port)/10;
+            printf(" \"volt\" : %0.1f,", volt);
 
-		printf(" }");
-		printf("\r\n");
-		setDateTime(serial_port);
+            Gyro_Sensor gyro;
+            gmc_get_gyro(serial_port, &gyro);
+            printf(" \"x\" : %d,\"y\" : %d, \"z\" : %d", gyro.x, gyro.y, gyro.z);
+        printf(" }");
+
+    printf(" }");
+    printf("\r\n");
+    setDateTime(serial_port);
 	gmc_close(serial_port);
 
   return 0; // success

--- a/rootfs/gmc320.c
+++ b/rootfs/gmc320.c
@@ -4,6 +4,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 #include <fcntl.h> // Contains file controls like O_RDWR
 #include <errno.h> // Error integer and strerror() function
 #include <termios.h> // Contains POSIX terminal control definitions
@@ -208,8 +209,23 @@ int main(int argc, char *argv[]) {
 		printf("You need to specify the serial device used by the GMC radation monotor i.e. %s /dev/ttyUSB0\n", argv[0]);
 		return 1;
 	}
+	int baudrate = 115200;
+	char* p;
+	// try parse baudrate from argv
+	if (argc >= 3){
+		if(strlen(argv[2]) > 0){
+			long argv2 = strtol(argv[2], &p, 10);
+			if (*p != '\0' || errno != 0) {
+			    	printf("failed to parse baudrate, fallback to default");
+				baudrate = 115200;
+			}
+			baudrate = (int)argv2;
+		}
+	}
+
+	
 //	serial_port = gmc_open("/dev/ttyUSB0", 19200);
-	serial_port = gmc_open(argv[1], 19200);
+	serial_port = gmc_open(argv[1], (int)baudrate);
 	if (serial_port == -1) {
 		printf("Cannot open specified serial device\n");
 		return 1;

--- a/rootfs/gmc320.c
+++ b/rootfs/gmc320.c
@@ -206,7 +206,7 @@ int setDateTime(int device) {
 int main(int argc, char *argv[]) {
 
 	if (argc != 2) {
-		printf("You need to specify the serial device used by the GMC radation monotor i.e. %s /dev/ttyUSB0\n", argv[0]);
+		printf("You need to specify the serial device used by the GMC radiation monitor i.e. %s /dev/ttyUSB0\n", argv[0]);
 		return 1;
 	}
 	int baudrate = 115200;
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
 		if(strlen(argv[2]) > 0){
 			long argv2 = strtol(argv[2], &p, 10);
 			if (*p != '\0' || errno != 0) {
-			    	printf("failed to parse baudrate, fallback to default");
+			    	printf("failed to parse baud rate, fallback to default");
 				baudrate = 115200;
 			}
 			baudrate = (int)argv2;


### PR DESCRIPTION
Using the default homeassistant API completlely eliminates the need to use MQTT.
The sensor state consists of the cpm (state) and additional attributes like the gyro values.
Details are added to the README.md.

If this repo is not longer maintained, feel free to use my fork: https://github.com/alex-vg/gmc3xx